### PR TITLE
fix: multiple imports

### DIFF
--- a/frappe_types/frappe_types/type_generator.py
+++ b/frappe_types/frappe_types/type_generator.py
@@ -82,7 +82,7 @@ def generate_type_definition_content(doctype, module_path, generate_child_tables
         file_defination, statement = get_field_type_definition(
             field, doctype, module_path, generate_child_tables)
 
-        if statement:
+        if statement and import_statement.find(statement) == -1:
             import_statement += statement
         
         content += "\t" + file_defination + "\n"


### PR DESCRIPTION
Issue: Multiple import statements are added if the Doctype uses the same Table multiple times.

Proof:
![Screenshot 2024-03-04 004058](https://github.com/The-Commit-Company/frappe-types/assets/48860013/88e30c85-7c48-426c-9fe5-0a4ef3598663)

Fix: Check whether the statement is available in the import_statements variable.